### PR TITLE
Fix: Input Texture Size

### DIFF
--- a/Assets/YOLO/Scripts/ObjectDetection/TextureAnalyser.cs
+++ b/Assets/YOLO/Scripts/ObjectDetection/TextureAnalyser.cs
@@ -14,9 +14,9 @@ namespace YOLOQuestUnity.ObjectDetection
             _worker = worker;
         }
 
-        public Awaitable<Tensor<float>> AnalyseTexture(Texture2D texture)
+        public Awaitable<Tensor<float>> AnalyseTexture(Texture2D texture, int size)
         { 
-            TextureTransform textureTransform = new TextureTransform().SetChannelSwizzle().SetDimensions(640, 640, 3);
+            TextureTransform textureTransform = new TextureTransform().SetChannelSwizzle().SetDimensions(size, size, 3);
             _input = TextureConverter.ToTensor(texture, textureTransform);
         
             _worker.Schedule(_input);
@@ -26,9 +26,9 @@ namespace YOLOQuestUnity.ObjectDetection
             return output;
         }
 
-        public IEnumerator AnalyseTextureWithLayerControl(Texture2D texture)
+        public IEnumerator AnalyseTextureWithLayerControl(Texture2D texture, int size)
         {
-            TextureTransform textureTransform = new TextureTransform().SetChannelSwizzle().SetDimensions(640, 640, 3);
+            TextureTransform textureTransform = new TextureTransform().SetChannelSwizzle().SetDimensions(size, size, 3);
             _input = TextureConverter.ToTensor(texture, textureTransform);
 
             var output =_worker.ScheduleIterable(_input);

--- a/Assets/YOLO/Scripts/ObjectDetection/YOLOInferenceHandler.cs
+++ b/Assets/YOLO/Scripts/ObjectDetection/YOLOInferenceHandler.cs
@@ -12,11 +12,13 @@ namespace YOLOQuestUnity.ObjectDetection
         private TextureAnalyser _textureAnalyser;
         private int _size;
 
-        public YOLOInferenceHandler(ModelAsset modelAsset, int size)
+        public YOLOInferenceHandler(ModelAsset modelAsset, out int size)
         {
-            _size = size;
             _model = ModelLoader.Load(modelAsset);
-            
+
+            size = _model.inputs[0].shape.Get(2);
+            _size = size;
+
             if (modelAsset.name.Contains("yolo11"))
             {
                 var graph = new FunctionalGraph();
@@ -45,7 +47,7 @@ namespace YOLOQuestUnity.ObjectDetection
 
             //ResizeTool.Resize(input, _size, _size, false, input.filterMode);
 
-            return _textureAnalyser.AnalyseTexture(input);
+            return _textureAnalyser.AnalyseTexture(input, _size);
         }
 
         public override IEnumerator RunWithLayerControl(Texture2D input)
@@ -55,7 +57,7 @@ namespace YOLOQuestUnity.ObjectDetection
 
             //ResizeTool.Resize(input, _size, _size, false, input.filterMode);
 
-            return _textureAnalyser.AnalyseTextureWithLayerControl(input);
+            return _textureAnalyser.AnalyseTextureWithLayerControl(input, _size);
         }
 
         public override void DisposeTensors()

--- a/Assets/YOLO/Scripts/YOLOHandler.cs
+++ b/Assets/YOLO/Scripts/YOLOHandler.cs
@@ -18,8 +18,6 @@ namespace YOLOQuestUnity.YOLO
 
         #region Inputs
 
-        [Tooltip("The size the input image will be converted to before running the model. Here for future use. Currently has no functionality.")]
-        [SerializeField] private int Size = 640;
         [Tooltip("The YOLO model to run.")]
         [SerializeField] private ModelAsset _model;
         [Tooltip("The VideoFeedManager to analyse frames from.")]
@@ -35,6 +33,7 @@ namespace YOLOQuestUnity.YOLO
 
         #region InstanceFields
 
+        private int Size = 640;
         private InferenceHandler<Texture2D> _inferenceHandler;
         private int _frameCount;
 
@@ -76,7 +75,7 @@ namespace YOLOQuestUnity.YOLO
         {
             var classJsonString = _classJson.text;
             _classes = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, Dictionary<int, string>>>(classJsonString)["class"];
-            _inferenceHandler = new YOLOInferenceHandler(_model, 640);
+            _inferenceHandler = new YOLOInferenceHandler(_model, out Size);
             if (_layersPerFrame == 0) _layersPerFrame = 1;
             slider.onValueChanged.AddListener(SetLayersPerFrame);
         }


### PR DESCRIPTION
## Changes

### Fixes

* Fixes potential bug arising from mismatch between inspector value and real input size.
* Uses size property of YOLOHandler for both coordinate calculation and input texture resizing, whilst removing control of this property from the inspector.

#### Significant files

* YOLOHandler.cs
* YOLOInferenceHandler.cs
* TextureAnalyser.cs

### Related issues

* #21 